### PR TITLE
Refactor reading list layout

### DIFF
--- a/_includes/book_item.html
+++ b/_includes/book_item.html
@@ -1,0 +1,25 @@
+<li class="book-item"{% if include.last_name %} data-last-name="{{ include.last_name }}"{% endif %}>
+  <div>
+    {% assign content_size = include.book.content | strip | size %}
+    {% if content_size > 0 %}
+      <a href="{{ include.book.url }}" rel="nofollow noopener" class="book-title-link{% if include.book.stars == 5 %} highlight{% endif %}">
+        {{ include.book.title }} <span class="note-icon">📝</span>
+      </a>
+    {% else %}
+      <span class="book-title{% if include.book.stars == 5 %} highlight{% endif %}">{{ include.book.title }}</span>
+    {% endif %}
+    <span class="book-author{% if include.book.stars == 5 %} highlight{% endif %}">by {{ include.book.author }}</span>
+  </div>
+  <span class="book-rating">
+    {% if include.unrated %}
+      Unrated
+    {% else %}
+      {% if include.book.currently_reading %}
+        <span class="currently-reading">Started: {{ include.book.date | date: "%b %d" }}</span>
+      {% elsif include.book.stars %}
+        {% assign star_count = include.book.stars %}
+        <span class="stars">{% for i in (1..star_count) %}★{% endfor %}</span>
+      {% endif %}
+    {% endif %}
+  </span>
+</li>

--- a/reading.md
+++ b/reading.md
@@ -9,12 +9,14 @@ layout: base
 <p>These are books I've read since January 2023 (plus some greats from previous years).
   Any book with a 📝 icon contains my reading notes, favorite quotes, and a summary.
 </p>
-<p>  You can sort this list by
+<div class="sort-menu">
+<p>You can sort this list by
   <a href="#" onclick="showList('date'); return false;">date</a>,
   <a href="#" onclick="showList('rating'); return false;">rating</a>,
   <a href="#" onclick="showList('title'); return false;">title</a>, or
   <a href="#" onclick="showList('author'); return false;">author</a>.
 </p>
+</div>
 
 <hr/>
 
@@ -28,29 +30,9 @@ layout: base
         <div>
             <h2>{{ year }}</h2>
             <p>{{ year_group.items | size }} books</p>
-            <ul style="list-style-type: none; padding: 0;">
+            <ul class="book-list">
                 {% for book in year_group.items %}
-                    <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;">
-                        <div>
-                            {% assign content_size = book.content | strip | size %}
-                            {% if content_size > 0 %}
-                                <a href="{{ book.url }}" rel="nofollow noopener" style="{% if book.stars == 5 %}font-weight: bold;{% endif %} text-decoration: none; display: block;">
-                                    {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-                                </a>
-                            {% else %}
-                                <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block;">{{ book.title }}</span>
-                            {% endif %}
-                            <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-                        </div>
-                        <span style="white-space: nowrap; color: {% if book.stars == 5 %}gold{% endif %};">
-                            {% if book.currently_reading %}
-                                <span style="display: block; font-size: 0.8em; color: #999;">Started: {{ book.date | date: "%b %d" }}</span>
-                            {% elsif book.stars %}
-                                {% assign star_count = book.stars %}
-                                {% for i in (1..star_count) %}★{% endfor %}
-                            {% endif %}
-                        </span>
-                    </li>
+                    {% include book_item.html book=book %}
                 {% endfor %}
             </ul>
         </div>
@@ -58,27 +40,9 @@ layout: base
         <div>
             <h2>Previous Years</h2>
             <p>{{ year_group.items | size }} books</p>
-            <ul style="list-style-type: none; padding: 0;">
+            <ul class="book-list">
                 {% for book in year_group.items %}
-                    <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;">
-                        <div>
-                            {% assign content_size = book.content | strip | size %}
-                            {% if content_size > 0 %}
-                                <a href="{{ book.url }}" rel="nofollow noopener" style="{% if book.stars == 5 %}font-weight: bold;{% endif %} text-decoration: none; display: block;">
-                                    {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-                                </a>
-                            {% else %}
-                                <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block;">{{ book.title }}</span>
-                            {% endif %}
-                            <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-                        </div>
-                        <span style="white-space: nowrap; color: {% if book.stars == 5 %}gold{% else %}black{% endif %};">
-                            {% if book.stars %}
-                                {% assign star_count = book.stars %}
-                                {% for i in (1..star_count) %}★{% endfor %}
-                            {% endif %}
-                        </span>
-                    </li>
+                    {% include book_item.html book=book %}
                 {% endfor %}
             </ul>
         </div>
@@ -89,100 +53,84 @@ layout: base
 <div id="rating-list" style="display: none;">
   {% assign rated_books = site.books | where_exp: "book", "book.stars" | sort: "stars" | reverse %}
   {% assign unrated_books = site.books | where_exp: "book", "book.stars == nil" %}
-  <ul style="list-style-type: none; padding: 0;">
+  <ul class="book-list">
     {% for book in rated_books %}
-      <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;">
-        <div>
-          {% assign content_size = book.content | strip | size %}
-          {% if content_size > 0 %}
-            <a href="{{ book.url }}" rel="nofollow noopener" style="{% if book.stars == 5 %}font-weight: bold;{% endif %} text-decoration: none; display: block;">
-              {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-            </a>
-          {% else %}
-            <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block;">{{ book.title }}</span>
-          {% endif %}
-          <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-        </div>
-        <span style="white-space: nowrap; color: {% if book.stars == 5 %}gold{% endif %};">
-          {% assign star_count = book.stars %}
-          {% for i in (1..star_count) %}★{% endfor %}
-        </span>
-      </li>
+      {% include book_item.html book=book %}
     {% endfor %}
     {% for book in unrated_books %}
-      <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;">
-        <div>
-          {% assign content_size = book.content | strip | size %}
-          {% if content_size > 0 %}
-            <a href="{{ book.url }}" rel="nofollow noopener" style="text-decoration: none; display: block;">
-              {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-            </a>
-          {% else %}
-            <span style="display: block;">{{ book.title }}</span>
-          {% endif %}
-          <span style="display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-        </div>
-        <span style="white-space: nowrap;">Unrated</span>
-      </li>
+      {% include book_item.html book=book unrated=true %}
     {% endfor %}
   </ul>
 </div>
 
 <div id="title-list" style="display: none;">
   {% assign sorted_books = site.books | sort: "title" %}
-  <ul style="list-style-type: none; padding: 0;">
+  <ul class="book-list">
     {% for book in sorted_books %}
-      <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;">
-        <div>
-          {% assign content_size = book.content | strip | size %}
-          {% if content_size > 0 %}
-            <a href="{{ book.url }}" rel="nofollow noopener" style="{% if book.stars == 5 %}font-weight: bold;{% endif %} text-decoration: none; display: block;">
-              {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-            </a>
-          {% else %}
-            <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block;">{{ book.title }}</span>
-          {% endif %}
-          <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-        </div>
-        <span style="white-space: nowrap; color: {% if book.stars == 5 %}gold{% endif %};">
-          {% if book.stars %}
-            {% assign star_count = book.stars %}
-            {% for i in (1..star_count) %}★{% endfor %}
-          {% endif %}
-        </span>
-      </li>
+      {% include book_item.html book=book %}
     {% endfor %}
   </ul>
 </div>
 
 <div id="author-list" style="display: none;">
   {% assign sorted_books = site.books | sort_natural: "author" %}
-  <ul style="list-style-type: none; padding: 0;">
+  <ul class="book-list">
     {% for book in sorted_books %}
       {% assign words = book.author | split: ' ' %}
       {% assign last_name = words | last %}
-      <li style="display: grid; grid-template-columns: auto min-content; gap: 10px; align-items: start; margin-bottom: 10px;" data-last-name="{{ last_name }}">
-        <div>
-          {% assign content_size = book.content | strip | size %}
-          {% if content_size > 0 %}
-            <a href="{{ book.url }}" rel="nofollow noopener" style="{% if book.stars == 5 %}font-weight: bold;{% endif %} text-decoration: none; display: block;">
-              {{ book.title }} <span style="font-size: 0.8em; color: #4a4a4a;">📝</span>
-            </a>
-          {% else %}
-            <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block;">{{ book.title }}</span>
-          {% endif %}
-          <span style="{% if book.stars == 5 %}font-weight: bold;{% endif %} display: block; font-size: 0.8em; color: #999;">by {{ book.author }}</span>
-        </div>
-        <span style="white-space: nowrap; color: {% if book.stars == 5 %}gold{% endif %};">
-          {% if book.stars %}
-            {% assign star_count = book.stars %}
-            {% for i in (1..star_count) %}★{% endfor %}
-          {% endif %}
-        </span>
-      </li>
+      {% include book_item.html book=book last_name=last_name %}
     {% endfor %}
   </ul>
 </div>
+
+<style>
+  .sort-menu {
+    position: sticky;
+    top: 0;
+    background: white;
+    padding: 0.5em 0;
+  }
+  .book-list {
+    list-style-type: none;
+    padding: 0;
+  }
+  .book-item {
+    display: grid;
+    grid-template-columns: auto min-content;
+    gap: 10px;
+    align-items: start;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+  }
+  .book-title-link, .book-title {
+    display: block;
+    text-decoration: none;
+  }
+  .book-author {
+    display: block;
+    font-size: 0.8em;
+    color: #999;
+  }
+  .note-icon {
+    font-size: 0.8em;
+    color: #4a4a4a;
+  }
+  .highlight {
+    font-weight: bold;
+  }
+  .book-rating {
+    white-space: nowrap;
+  }
+  .book-rating .currently-reading {
+    display: block;
+    font-size: 0.8em;
+    color: #999;
+  }
+  .stars {
+    color: gold;
+  }
+</style>
 
 <script>
 function showList(listType) {


### PR DESCRIPTION
## Summary
- create reusable include for individual book items
- simplify HTML in `reading.md` using the new include
- add a sticky sorting menu
- move styles for the reading list into a single style block

## Testing
- `bundle exec jekyll build` *(fails: Could not find jekyll-4.3.3, minima-2.5.1, jekyll-feed-0.17.0, jekyll-sitemap-1.4.0, jekyll-remote-theme-0.4.3, addressable-2.8.6, i18n-1.14.5, jekyll-sass-converter-3.0.0, kramdown-2.4.0, rouge-4.2.1, webrick-1.8.1, jekyll-seo-tag-2.8.0, rubyzip-2.3.2, public_suffix-5.0.5, concurrent-ruby-1.2.3, rexml-3.2.6, unicode-display_width-2.5.0, rb-inotify-0.10.1, ffi-1.16.3 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6841101c999883238289d141118dc97a